### PR TITLE
Update detection of 64 bit architecture

### DIFF
--- a/bt_manager/codecs.py
+++ b/bt_manager/codecs.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 from bt_manager import ffi
 import os
-import platform
+import sys
 
 A2DP_CODECS = {'SBC': 0x00,
                'MPEG12': 0x01,
@@ -93,11 +93,9 @@ class SBCCodec:
     """
 
     def __init__(self, config):
-
-        import sys
-
         so_path = './librtpsbc.so'
-        if platform.machine() == 'aarch64':
+        is_64bits = sys.maxsize > 2**32 # https://docs.python.org/3/library/platform.html#platform.architecture
+        if is_64bits:
             so_path = './librtpsbc_aarch64.so'
 
         try:


### PR DESCRIPTION
On recent versions of raspbian, the old method of detection would erroneously detect a 64 bit OS, when in fact a 32 bit OS was running. See this for more context on why: https://raspberrypi.stackexchange.com/questions/143287/i-installed-raspbian-32-bit-but-arch-writes-aarch64

This would result in errors connecting to bluetooth:

Jan 28 07:33:17 pifi bt_speaker.py[27596]: Exception:<class 'OSError'>
Jan 28 07:33:17 pifi bt_speaker.py[27596]: cannot load library './librtpsbc_aarch64.so': ./librtpsbc_aarch64.so: wrong ELF class: ELFCLASS64.  Additionally, ctypes.util.find_library() did not manage to locate a library called './librtpsbc_aarch64.so'